### PR TITLE
feat: better pricing and limits for requests per minute

### DIFF
--- a/apps/web/src/utils/plans.ts
+++ b/apps/web/src/utils/plans.ts
@@ -1,5 +1,6 @@
-import type { ButtonProps } from "#/components/ui/button.tsx";
 import type { PlanType } from "@screenshothis/schemas/plan";
+
+import type { ButtonProps } from "#/components/ui/button.tsx";
 
 export type Plan = {
 	name: string;
@@ -16,10 +17,10 @@ export type Plan = {
 export const plans: Record<Exclude<PlanType, "free">, Plan> = {
 	lite: {
 		name: "Lite",
-		price: 5,
+		price: 9.99,
 		features: [
-			"<strong>1,000 Screenshots</strong> are included",
-			"<strong>300 requests</strong> each minute",
+			"<strong>2,000 Screenshots</strong> are included",
+			"<strong>400 requests</strong> each minute",
 			"Blocks ads and cookie banners",
 			"Takes full-page screenshots",
 			"Includes caching <sup class='text-sub text-primary'>1</sup>",

--- a/apps/web/src/utils/plans.ts
+++ b/apps/web/src/utils/plans.ts
@@ -36,7 +36,7 @@ export const plans: Record<Exclude<PlanType, "free">, Plan> = {
 		isFeatured: true,
 		features: [
 			"<strong>10,000 Screenshots</strong> are included",
-			"<strong>600 requests</strong> each minute",
+			"<strong>300 requests</strong> each minute",
 			"Blocks ads and cookie banners",
 			"Takes full-page screenshots",
 			"Includes caching <sup class='text-sub text-white'>1</sup>",
@@ -51,7 +51,7 @@ export const plans: Record<Exclude<PlanType, "free">, Plan> = {
 		price: 49,
 		features: [
 			"<strong>100,000 Screenshots</strong> are included",
-			"<strong>6,000 requests</strong> each minute",
+			"<strong>3,000 requests</strong> each minute",
 			"Blocks ads and cookie banners",
 			"Takes full-page screenshots",
 			"Includes caching <sup class='text-sub text-primary'>1</sup>",

--- a/apps/web/src/utils/plans.ts
+++ b/apps/web/src/utils/plans.ts
@@ -20,7 +20,7 @@ export const plans: Record<Exclude<PlanType, "free">, Plan> = {
 		price: 9.99,
 		features: [
 			"<strong>2,000 Screenshots</strong> are included",
-			"<strong>400 requests</strong> each minute",
+			"<strong>60 requests</strong> each minute",
 			"Blocks ads and cookie banners",
 			"Takes full-page screenshots",
 			"Includes caching <sup class='text-sub text-primary'>1</sup>",

--- a/packages/common/src/keys.ts
+++ b/packages/common/src/keys.ts
@@ -51,7 +51,7 @@ export const THIRTY_DAYS_MS = BigInt(30 * 24 * 60 * 60 * 1_000); // 30 days
 export const keyLimits: Record<PlanType, Limit> = {
 	free: {
 		rateLimitTimeWindow: 60 * 1000, // 1 minute
-		rateLimitMax: 60, // 60 requests per minute
+		rateLimitMax: 10, // 10 requests per minute
 		rateLimitEnabled: true,
 		metadata: {
 			totalRequests: 0,
@@ -65,7 +65,7 @@ export const keyLimits: Record<PlanType, Limit> = {
 	},
 	lite: {
 		rateLimitTimeWindow: 60 * 1000, // 1 minute
-		rateLimitMax: 400, // 400 requests per minute
+		rateLimitMax: 60, // 60 requests per minute
 		rateLimitEnabled: true,
 		metadata: {
 			totalRequests: 0,
@@ -79,7 +79,7 @@ export const keyLimits: Record<PlanType, Limit> = {
 	},
 	pro: {
 		rateLimitTimeWindow: 60 * 1000, // 1 minute
-		rateLimitMax: 600, // 600 requests per minute
+		rateLimitMax: 300, // 300 requests per minute
 		rateLimitEnabled: true,
 		metadata: {
 			totalRequests: 0,
@@ -93,7 +93,7 @@ export const keyLimits: Record<PlanType, Limit> = {
 	},
 	enterprise: {
 		rateLimitTimeWindow: 60 * 1000, // 1 minute
-		rateLimitMax: 6000, // 6000 requests per minute
+		rateLimitMax: 3000, // 3000 requests per minute
 		rateLimitEnabled: true,
 		metadata: {
 			totalRequests: 0,

--- a/packages/common/src/keys.ts
+++ b/packages/common/src/keys.ts
@@ -65,14 +65,14 @@ export const keyLimits: Record<PlanType, Limit> = {
 	},
 	lite: {
 		rateLimitTimeWindow: 60 * 1000, // 1 minute
-		rateLimitMax: 300, // 300 requests per minute
+		rateLimitMax: 400, // 400 requests per minute
 		rateLimitEnabled: true,
 		metadata: {
 			totalRequests: 0,
-			totalAllowedRequests: 1000,
-			remainingRequests: 1000,
+			totalAllowedRequests: 2000,
+			remainingRequests: 2000,
 			plan: "lite",
-			refillAmount: 1000,
+			refillAmount: 2000,
 			refillInterval: THIRTY_DAYS_MS,
 			isExtraEnabled: true,
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
	- The Lite plan price has increased from $5 to $9.99.
	- The Lite plan now includes 2,000 screenshots (up from 1,000).
	- Rate limit maximums for all subscription plans have been reduced by approximately half or more.
	- The Lite plan’s total allowed requests and refill amount have been doubled.
- **Other**
	- No changes to the structure or signatures of public features; only plan details and limits were updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->