### PR TITLE
feat(screenshots): add authorization option features

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,3 +310,12 @@ Please ensure your code adheres to the linting and formatting guidelines (`bun c
 ## 📄 License
 
 This project is licensed under the [MIT License](./LICENSE).
+
+## Security & Rate Limits
+
+- **Header size limit**: Each request's `headers` parameter is capped at 8 KB (8192 characters).
+- **Cookie size limit**: The `cookies` parameter is capped at 4 KB (4096 characters).
+- **Rate limiting**: Screenshot generation is limited via `requestLimits` (see server schema) and enforced per-user.
+- **CSP bypass auditing**: Every time `bypass_csp=true` is used, the event is audit-logged server-side for review.
+
+These constraints ensure reliable performance and mitigate abuse vectors per RFC 7230 and common security best practices.

--- a/apps/server/src/db/migrations/0009_nebulous_meteorite.sql
+++ b/apps/server/src/db/migrations/0009_nebulous_meteorite.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "screenshots" ADD COLUMN "user_agent" text;--> statement-breakpoint
+ALTER TABLE "screenshots" ADD COLUMN "headers" jsonb DEFAULT '[]'::jsonb NOT NULL;--> statement-breakpoint
+ALTER TABLE "screenshots" ADD COLUMN "cookies" jsonb DEFAULT '[]'::jsonb NOT NULL;--> statement-breakpoint
+ALTER TABLE "screenshots" ADD COLUMN "bypass_csp" boolean DEFAULT false NOT NULL;

--- a/apps/server/src/db/migrations/meta/0009_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,1157 @@
+{
+  "id": "27749d9c-e3f2-439f-976a-ff2aa1ce8181",
+  "prevId": "df809cc7-8b26-47d1-b1df-7b7b32c816ce",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_workspace_id": {
+          "name": "active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_email": {
+          "name": "normalized_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_normalized_email_unique": {
+          "name": "users_normalized_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "normalized_email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polar_customer_state": {
+      "name": "polar_customer_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_subscriptions": {
+          "name": "active_subscriptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "granted_benefits": {
+          "name": "granted_benefits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "active_meters": {
+          "name": "active_meters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polar_customer_state_external_id_users_id_fk": {
+          "name": "polar_customer_state_external_id_users_id_fk",
+          "tableFrom": "polar_customer_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "external_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "polar_customer_state_external_id_unique": {
+          "name": "polar_customer_state_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_limits": {
+      "name": "request_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_requests": {
+          "name": "total_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_allowed_requests": {
+          "name": "total_allowed_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_requests": {
+          "name": "remaining_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_extra_enabled": {
+          "name": "is_extra_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "request_limits_user_id_users_id_fk": {
+          "name": "request_limits_user_id_users_id_fk",
+          "tableFrom": "request_limits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.screenshots": {
+      "name": "screenshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mobile": {
+          "name": "is_mobile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_landscape": {
+          "name": "is_landscape",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "device_scale_factor": {
+          "name": "device_scale_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "duration": {
+          "name": "duration",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_touch": {
+          "name": "has_touch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_ads": {
+          "name": "block_ads",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block_cookie_banners": {
+          "name": "block_cookie_banners",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block_trackers": {
+          "name": "block_trackers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block_requests": {
+          "name": "block_requests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "block_resources": {
+          "name": "block_resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "prefers_color_scheme": {
+          "name": "prefers_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'light'"
+        },
+        "prefers_reduced_motion": {
+          "name": "prefers_reduced_motion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no-preference'"
+        },
+        "is_cached": {
+          "name": "is_cached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_ttl": {
+          "name": "cache_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3600
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cookies": {
+          "name": "cookies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "bypass_csp": {
+          "name": "bypass_csp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_extra": {
+          "name": "is_extra",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "screenshots_workspace_id_workspaces_id_fk": {
+          "name": "screenshots_workspace_id_workspaces_id_fk",
+          "tableFrom": "screenshots",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspaces_slug_unique": {
+          "name": "workspaces_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_invitations_inviter_id_users_id_fk": {
+          "name": "workspace_invitations_inviter_id_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_workspace_id_workspaces_id_fk": {
+          "name": "workspace_invitations_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_users_id_fk": {
+          "name": "workspace_members_user_id_users_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1747929481948,
       "tag": "0008_reflective_mindworm",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1748126432338,
+      "tag": "0009_nebulous_meteorite",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/screenshots.ts
+++ b/apps/server/src/db/schema/screenshots.ts
@@ -62,7 +62,18 @@ export const screenshots = pgTable("screenshots", {
 		.default([]),
 	cookies: jsonb("cookies")
 		.notNull()
-		.$type<Array<{ name: string; value: string }>>()
+		.$type<
+			Array<{
+				name: string;
+				value: string;
+				domain?: string;
+				path?: string;
+				expires?: number;
+				sameSite?: "lax" | "strict" | "none";
+				secure?: boolean;
+				httpOnly?: boolean;
+			}>
+		>()
 		.default([]),
 	bypassCsp: boolean("bypass_csp").notNull().default(false),
 	isExtra: boolean("is_extra").notNull().default(false),

--- a/apps/server/src/db/schema/screenshots.ts
+++ b/apps/server/src/db/schema/screenshots.ts
@@ -56,8 +56,14 @@ export const screenshots = pgTable("screenshots", {
 	cacheTtl: integer("cache_ttl").default(3600),
 	cacheKey: text("cache_key"),
 	userAgent: text("user_agent"),
-	headers: jsonb("headers").notNull().$type<Array<string>>().default([]),
-	cookies: jsonb("cookies").notNull().$type<Array<string>>().default([]),
+	headers: jsonb("headers")
+		.notNull()
+		.$type<Array<{ name: string; value: string }>>()
+		.default([]),
+	cookies: jsonb("cookies")
+		.notNull()
+		.$type<Array<{ name: string; value: string }>>()
+		.default([]),
 	bypassCsp: boolean("bypass_csp").notNull().default(false),
 	isExtra: boolean("is_extra").notNull().default(false),
 	workspaceId: text("workspace_id")

--- a/apps/server/src/db/schema/screenshots.ts
+++ b/apps/server/src/db/schema/screenshots.ts
@@ -16,6 +16,7 @@ import {
 } from "drizzle-orm/pg-core";
 import type { z } from "zod";
 
+import type { CookieSameSite } from "puppeteer";
 import { timestamps } from "./utils/timestamps";
 import { workspace } from "./workspaces";
 
@@ -69,7 +70,7 @@ export const screenshots = pgTable("screenshots", {
 				domain?: string;
 				path?: string;
 				expires?: number;
-				sameSite?: "lax" | "strict" | "none";
+				sameSite?: CookieSameSite | undefined;
 				secure?: boolean;
 				httpOnly?: boolean;
 			}>

--- a/apps/server/src/db/schema/screenshots.ts
+++ b/apps/server/src/db/schema/screenshots.ts
@@ -55,6 +55,10 @@ export const screenshots = pgTable("screenshots", {
 	isCached: boolean("is_cached").notNull().default(false),
 	cacheTtl: integer("cache_ttl").default(3600),
 	cacheKey: text("cache_key"),
+	userAgent: text("user_agent"),
+	headers: jsonb("headers").notNull().$type<Array<string>>().default([]),
+	cookies: jsonb("cookies").notNull().$type<Array<string>>().default([]),
+	bypassCsp: boolean("bypass_csp").notNull().default(false),
 	isExtra: boolean("is_extra").notNull().default(false),
 	workspaceId: text("workspace_id")
 		.notNull()

--- a/apps/server/src/lib/screenshot-queue.ts
+++ b/apps/server/src/lib/screenshot-queue.ts
@@ -190,6 +190,10 @@ export async function getExistingScreenshotKey(
 		isCached,
 		cacheTtl,
 		cacheKey,
+		userAgent,
+		headers,
+		cookies,
+		bypassCsp,
 	} = params;
 
 	try {
@@ -215,6 +219,10 @@ export async function getExistingScreenshotKey(
 				eq(screenshots.isCached, isCached),
 				cacheTtl ? eq(screenshots.cacheTtl, cacheTtl) : undefined,
 				cacheKey ? eq(screenshots.cacheKey, cacheKey) : undefined,
+				userAgent ? eq(screenshots.userAgent, userAgent) : undefined,
+				sql`${screenshots.headers} @> ${JSON.stringify(headers || [])}`,
+				sql`${screenshots.cookies} @> ${JSON.stringify(cookies || [])}`,
+				eq(screenshots.bypassCsp, bypassCsp),
 			),
 		});
 

--- a/apps/server/src/lib/screenshot-queue.ts
+++ b/apps/server/src/lib/screenshot-queue.ts
@@ -215,7 +215,6 @@ export async function getExistingScreenshotKey(
 		bypassCsp,
 	} = params;
 
-	// Normalize header/cookie arrays for consistent query matching
 	const normalizedHeaders = normalizeStringArray(headers);
 	const normalizedCookies = normalizeStringArray(cookies);
 

--- a/apps/server/src/utils/screenshot.ts
+++ b/apps/server/src/utils/screenshot.ts
@@ -59,8 +59,8 @@ export async function getOrCreateScreenshot(
 			cacheTtl,
 			cacheKey,
 			userAgent,
-			headers,
-			cookies,
+			headers = [],
+			cookies = [],
 			bypassCsp,
 		} = params;
 

--- a/apps/server/src/utils/screenshot.ts
+++ b/apps/server/src/utils/screenshot.ts
@@ -206,6 +206,9 @@ export async function getOrCreateScreenshot(
 
 		if (bypassCsp) {
 			await page.setBypassCSP(true);
+			console.warn(
+				`[AUDIT] bypass_csp enabled for workspace ${workspaceId} on URL ${url}`,
+			);
 		}
 
 		page.emulateMediaFeatures([

--- a/apps/server/src/utils/screenshot.ts
+++ b/apps/server/src/utils/screenshot.ts
@@ -230,6 +230,8 @@ export async function getOrCreateScreenshot(
 				separator: false,
 			});
 
+			await page.setRequestInterception(true);
+
 			page.on("request", (request) => {
 				if (blockResources?.includes(request.resourceType() as never)) {
 					request.abort();

--- a/apps/server/src/utils/screenshot.ts
+++ b/apps/server/src/utils/screenshot.ts
@@ -10,7 +10,7 @@ import type {
 import fetch from "cross-fetch";
 import { and, eq, sql } from "drizzle-orm";
 import pLimit from "p-limit";
-import type { CookieData } from "puppeteer";
+import type { CookieData, CookieSameSite } from "puppeteer";
 import puppeteer from "puppeteer-extra";
 import StealthPlugin from "puppeteer-extra-plugin-stealth";
 import type { ObjectToCamel } from "ts-case-convert";
@@ -129,11 +129,13 @@ export async function getOrCreateScreenshot(
 				domain: (c.domain ?? urlObj.hostname) as string,
 				path: (c.path ?? "/") as string,
 				expires: c.expires as number | undefined,
-				sameSite: c.sameSite as import("puppeteer").CookieSameSite | undefined,
+				sameSite: c.sameSite as CookieSameSite | undefined,
 				secure: c.secure as boolean | undefined,
 				httpOnly: c.httpOnly as boolean | undefined,
 			}));
-			if (cookieObjs.length > 0) await browser.setCookie(...cookieObjs);
+			if (cookieObjs.length > 0) {
+				await browser.defaultBrowserContext().setCookie(...cookieObjs);
+			}
 		}
 
 		const page = await browser.newPage();

--- a/apps/web/src/components/forms/field.tsx
+++ b/apps/web/src/components/forms/field.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import InformationCircleSolidIcon from "virtual:icons/hugeicons/information-circle-solid";
+
 import * as m from "motion/react-m";
 import * as React from "react";
 
@@ -11,13 +13,15 @@ export type FieldProps = {
 	label?: React.ReactNode;
 	labelSub?: React.ReactNode;
 	labelClassName?: string;
-	hint?: string | Array<string>;
 	id?: string;
 	className?: string;
 	disabled?: boolean;
-	error?: string | Array<string>;
 	children: React.ReactNode;
+	hint?: string | Array<string>;
 	hintClassName?: string;
+	hintIcon?: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
+	hintIconClassName?: string;
+	error?: string | Array<string>;
 };
 
 const HintRootMotion = m.create(Hint.Root);
@@ -31,6 +35,8 @@ export function Field({
 	children,
 	hint,
 	hintClassName,
+	hintIcon = InformationCircleSolidIcon,
+	hintIconClassName,
 	...props
 }: FieldProps) {
 	const generatedId = React.useId();
@@ -68,7 +74,7 @@ export function Field({
 					animate={{ opacity: 1, height: "auto" }}
 					exit={{ opacity: 0, height: 0 }}
 				>
-					<Hint.Icon />
+					<Hint.Icon as={hintIcon} className={hintIconClassName} />
 					<span className="mt-px">{error || hint}</span>
 				</HintRootMotion>
 			) : null}

--- a/apps/web/src/components/forms/switch-field.tsx
+++ b/apps/web/src/components/forms/switch-field.tsx
@@ -16,6 +16,8 @@ export function SwitchField({
 	labelClassName,
 	hint,
 	hintClassName,
+	hintIcon,
+	hintIconClassName,
 	id: idProp,
 	...rest
 }: SwitchFieldProps) {
@@ -33,6 +35,8 @@ export function SwitchField({
 			error={error}
 			hint={hint}
 			hintClassName={hintClassName}
+			hintIcon={hintIcon}
+			hintIconClassName={hintIconClassName}
 			id={`${id}-form-item`}
 			className={wrapperClassName}
 		>

--- a/apps/web/src/components/forms/text-field.tsx
+++ b/apps/web/src/components/forms/text-field.tsx
@@ -24,6 +24,8 @@ export function TextField({
 	inlineTrailingNode,
 	hint,
 	hintClassName,
+	hintIcon,
+	hintIconClassName,
 	...rest
 }: TextFieldProps) {
 	const field = useFieldContext<string | number>();
@@ -40,6 +42,8 @@ export function TextField({
 			error={error}
 			hint={hint}
 			hintClassName={hintClassName}
+			hintIcon={hintIcon}
+			hintIconClassName={hintIconClassName}
 			id={id}
 			className={cn("flex flex-col gap-1", wrapperClassName)}
 		>

--- a/apps/web/src/components/forms/textarea.tsx
+++ b/apps/web/src/components/forms/textarea.tsx
@@ -19,6 +19,8 @@ export function Textarea({
 	labelClassName,
 	hint,
 	hintClassName,
+	hintIcon,
+	hintIconClassName,
 	...rest
 }: TextFieldProps) {
 	const field = useFieldContext<string>();
@@ -35,6 +37,8 @@ export function Textarea({
 			error={error}
 			hint={hint}
 			hintClassName={hintClassName}
+			hintIcon={hintIcon}
+			hintIconClassName={hintIconClassName}
 			id={`${id}-form-item`}
 			className={cn("flex flex-col gap-1", wrapperClassName)}
 		>

--- a/apps/web/src/routes/_app/playground.tsx
+++ b/apps/web/src/routes/_app/playground.tsx
@@ -1,4 +1,5 @@
 import AdvertisimentIcon from "virtual:icons/hugeicons/advertisiment";
+import Alert01SolidIcon from "virtual:icons/hugeicons/alert-01-solid";
 import CropIcon from "virtual:icons/hugeicons/crop";
 import Database02Icon from "virtual:icons/hugeicons/database-02";
 import DocumentCode01Icon from "virtual:icons/hugeicons/document-code";
@@ -526,7 +527,9 @@ function RouteComponent() {
 														name="user_agent"
 														id="user_agent"
 														placeholder="Mozilla/5.0 (Windows NT 10.0; Win64; x64)..."
-														hint="⚠️ Custom user agent strings can be used for fingerprinting; use responsibly."
+														hint="Custom user agent strings can be used for fingerprinting; use responsibly."
+														hintIcon={Alert01SolidIcon}
+														hintIconClassName="text-state-warning-base"
 													/>
 												)}
 											/>
@@ -543,7 +546,9 @@ function RouteComponent() {
 															"Authorization: Bearer <token>",
 															"X-Custom-Header: custom-value",
 														].join("\n")}
-														hint="⚠️ One header per line (Name: Value). Avoid adding security-sensitive headers."
+														hint="One header per line (Name: Value). Avoid adding security-sensitive headers."
+														hintIcon={Alert01SolidIcon}
+														hintIconClassName="text-state-warning-base"
 													/>
 												)}
 											/>
@@ -560,7 +565,9 @@ function RouteComponent() {
 															"sessionid=abc123; Domain=example.com; Path=/; HttpOnly",
 															"theme=dark; Path=/; SameSite=Lax",
 														].join("\n")}
-														hint="⚠️ One cookie per line. Only valid cookies; misuse may bypass security controls."
+														hint="One cookie per line. Only valid cookies; misuse may bypass security controls."
+														hintIcon={Alert01SolidIcon}
+														hintIconClassName="text-state-warning-base"
 													/>
 												)}
 											/>
@@ -572,7 +579,9 @@ function RouteComponent() {
 														label="Bypass CSP"
 														name="bypass_csp"
 														id="bypass_csp"
-														hint="⚠️ Bypasses Content Security Policy protections; use with extreme caution."
+														hint="Bypasses Content Security Policy protections; use with extreme caution."
+														hintIcon={Alert01SolidIcon}
+														hintIconClassName="text-state-warning-base"
 													/>
 												)}
 											/>

--- a/apps/web/src/routes/_app/playground.tsx
+++ b/apps/web/src/routes/_app/playground.tsx
@@ -514,7 +514,9 @@ function RouteComponent() {
 													<field.TextField
 														label="User Agent"
 														name="user_agent"
+														id="user_agent"
 														placeholder="Mozilla/5.0 (Windows NT 10.0; Win64; x64)..."
+														hint="⚠️ Custom user agent strings can be used for fingerprinting; use responsibly."
 													/>
 												)}
 											/>
@@ -525,12 +527,13 @@ function RouteComponent() {
 													<field.Textarea
 														label="Headers"
 														name="headers"
+														id="headers"
 														rows={5}
 														placeholder={[
 															"Authorization: Bearer <token>",
 															"X-Custom-Header: custom-value",
 														].join("\n")}
-														hint="One header per line in the format Name: Value"
+														hint="⚠️ One header per line (Name: Value). Avoid adding security-sensitive headers."
 													/>
 												)}
 											/>
@@ -541,12 +544,13 @@ function RouteComponent() {
 													<field.Textarea
 														label="Cookies"
 														name="cookies"
+														id="cookies"
 														rows={5}
 														placeholder={[
 															"sessionid=abc123; Domain=example.com; Path=/; HttpOnly",
 															"theme=dark; Path=/; SameSite=Lax",
 														].join("\n")}
-														hint="One cookie per line using standard syntax, e.g. name=value; Domain=example.com; Path=/; Secure; HttpOnly"
+														hint="⚠️ One cookie per line. Only valid cookies; misuse may bypass security controls."
 													/>
 												)}
 											/>
@@ -557,6 +561,8 @@ function RouteComponent() {
 													<field.SwitchField
 														label="Bypass CSP"
 														name="bypass_csp"
+														id="bypass_csp"
+														hint="⚠️ Bypasses Content Security Policy protections; use with extreme caution."
 													/>
 												)}
 											/>

--- a/apps/web/src/routes/_app/playground.tsx
+++ b/apps/web/src/routes/_app/playground.tsx
@@ -94,12 +94,10 @@ function RouteComponent() {
 				`   &block_cookie_banners=${values.block_cookie_banners}`,
 			values.block_trackers && `   &block_trackers=${values.block_trackers}`,
 			values.bypass_csp && `   &bypass_csp=${values.bypass_csp}`,
-			values.block_requests &&
-				values.block_requests.length > 0 &&
-				values.block_requests
-					?.split("\n")
-					?.map((request) => `   &block_requests=${request}`)
-					.join("\n"),
+			values.block_requests
+				?.split("\n")
+				?.map((request) => `   &block_requests=${request}`)
+				.join("\n"),
 			values.block_resources
 				?.map((resource) => `   &block_resources=${resource}`)
 				.join("\n"),
@@ -111,18 +109,30 @@ function RouteComponent() {
 			values.cache_ttl && `   &cache_ttl=${values.cache_ttl}`,
 			values.cache_key && `   &cache_key=${values.cache_key}`,
 			values.user_agent && `   &user_agent=${values.user_agent}`,
-			values.headers &&
-				values.headers.length > 0 &&
-				values.headers
-					.split("\n")
-					.map((h) => `   &headers=${encodeURIComponent(h)}`)
-					.join("\n"),
-			values.cookies &&
-				values.cookies.length > 0 &&
-				values.cookies
-					.split("\n")
-					.map((c) => `   &cookies=${encodeURIComponent(c)}`)
-					.join("\n"),
+			(() => {
+				const qp = new URLSearchParams();
+				const headerRegex = /^[\w!#$%&'*+.^`|~-]+:\s*[ -~]+$/i;
+				const cookieRegex = /[^=\s;]+=[^;]+/;
+
+				for (const h of values.headers
+					?.split("\n")
+					.map((l) => l.trim())
+					.filter(Boolean)
+					.filter((h) => headerRegex.test(h)) ?? []) {
+					qp.append("headers", h);
+				}
+
+				for (const c of values.cookies
+					?.split("\n")
+					.map((l) => l.trim())
+					.filter(Boolean)
+					.filter((c) => cookieRegex.test(c)) ?? []) {
+					qp.append("cookies", c);
+				}
+
+				if ([...qp.keys()].length === 0) return undefined;
+				return `   &${qp.toString().replace(/&/g, "\n   &")}`;
+			})(),
 		]
 			.filter(Boolean)
 			.join("\n");

--- a/apps/web/src/routes/_app/playground.tsx
+++ b/apps/web/src/routes/_app/playground.tsx
@@ -6,6 +6,7 @@ import EaseInOutIcon from "virtual:icons/hugeicons/ease-in-out";
 import Image01Icon from "virtual:icons/hugeicons/image-01";
 import Link01Icon from "virtual:icons/hugeicons/link-01";
 import PaintBrush02Icon from "virtual:icons/hugeicons/paint-brush-02";
+import SecurityLockIcon from "virtual:icons/hugeicons/security-lock";
 import ToggleOnIcon from "virtual:icons/hugeicons/toggle-on";
 import ZoomOutAreaIcon from "virtual:icons/hugeicons/zoom-out-area";
 
@@ -48,6 +49,10 @@ function RouteComponent() {
 			block_cookie_banners: true,
 			block_trackers: true,
 			prefers_color_scheme: "light",
+			user_agent: "",
+			headers: "",
+			cookies: "",
+			bypass_csp: false,
 		} as z.input<typeof CreateScreenshotSchema>,
 		onSubmit: async ({ value }) => {
 			await mutateAsync(value, {
@@ -88,6 +93,7 @@ function RouteComponent() {
 			values.block_cookie_banners &&
 				`   &block_cookie_banners=${values.block_cookie_banners}`,
 			values.block_trackers && `   &block_trackers=${values.block_trackers}`,
+			values.bypass_csp && `   &bypass_csp=${values.bypass_csp}`,
 			values.block_requests &&
 				values.block_requests.length > 0 &&
 				values.block_requests
@@ -104,6 +110,19 @@ function RouteComponent() {
 			values.is_cached && `   &is_cached=${values.is_cached}`,
 			values.cache_ttl && `   &cache_ttl=${values.cache_ttl}`,
 			values.cache_key && `   &cache_key=${values.cache_key}`,
+			values.user_agent && `   &user_agent=${values.user_agent}`,
+			values.headers &&
+				values.headers.length > 0 &&
+				values.headers
+					.split("\n")
+					.map((h) => `   &headers=${encodeURIComponent(h)}`)
+					.join("\n"),
+			values.cookies &&
+				values.cookies.length > 0 &&
+				values.cookies
+					.split("\n")
+					.map((c) => `   &cookies=${encodeURIComponent(c)}`)
+					.join("\n"),
 		]
 			.filter(Boolean)
 			.join("\n");
@@ -478,6 +497,69 @@ function RouteComponent() {
 													)}
 												/>
 											</div>
+										</Accordion.Content>
+									</Accordion.Item>
+
+									{/* Authorization */}
+									<Accordion.Item value="authorization">
+										<Accordion.Trigger>
+											<Accordion.Icon as={SecurityLockIcon} />
+											Authorization
+											<Accordion.Arrow />
+										</Accordion.Trigger>
+										<Accordion.Content className="mt-2 grid gap-3 px-7.5">
+											<form.AppField
+												name="user_agent"
+												children={(field) => (
+													<field.TextField
+														label="User Agent"
+														name="user_agent"
+														placeholder="Mozilla/5.0 (Windows NT 10.0; Win64; x64)..."
+													/>
+												)}
+											/>
+
+											<form.AppField
+												name="headers"
+												children={(field) => (
+													<field.Textarea
+														label="Headers"
+														name="headers"
+														rows={5}
+														placeholder={[
+															"Authorization: Bearer <token>",
+															"X-Custom-Header: custom-value",
+														].join("\n")}
+														hint="One header per line in the format Name: Value"
+													/>
+												)}
+											/>
+
+											<form.AppField
+												name="cookies"
+												children={(field) => (
+													<field.Textarea
+														label="Cookies"
+														name="cookies"
+														rows={5}
+														placeholder={[
+															"sessionid=abc123; Domain=example.com; Path=/; HttpOnly",
+															"theme=dark; Path=/; SameSite=Lax",
+														].join("\n")}
+														hint="One cookie per line using standard syntax, e.g. name=value; Domain=example.com; Path=/; Secure; HttpOnly"
+													/>
+												)}
+											/>
+
+											<form.AppField
+												name="bypass_csp"
+												children={(field) => (
+													<field.SwitchField
+														label="Bypass CSP"
+														name="bypass_csp"
+													/>
+												)}
+											/>
 										</Accordion.Content>
 									</Accordion.Item>
 								</Accordion.Root>

--- a/packages/schemas/src/screenshots.ts
+++ b/packages/schemas/src/screenshots.ts
@@ -101,7 +101,7 @@ export const ScreenshotSchema = z.object({
 					.filter((l): l is string => l.length > 0);
 				if (lines.length === 0) return true; // allow empty string handled by optional()
 				// Header value: visible ASCII (0x20-0x7E) only – excludes control chars (0x00–0x1F, 0x7F)
-				const headerRegex = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+:\s*[ -~]+$/;
+				const headerRegex = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+:\s*[ -~]*$/;
 				return lines.every((line) => headerRegex.test(line));
 			},
 			{

--- a/packages/schemas/src/screenshots.ts
+++ b/packages/schemas/src/screenshots.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+export const MAX_HEADERS_SIZE = 8192; // 8 KB (RFC 7230 guideline)
+export const MAX_COOKIES_SIZE = 4096; // 4 KB (typical cookie size limit)
+
 export const FormatSchema = z.enum(["jpeg", "png", "webp"]);
 export const ResourceTypeSchema = z.enum([
 	"document",
@@ -87,6 +90,9 @@ export const ScreenshotSchema = z.object({
 	user_agent: z.string().optional(),
 	headers: z
 		.string()
+		.max(MAX_HEADERS_SIZE, {
+			message: `Headers exceed maximum allowed size of ${MAX_HEADERS_SIZE} characters`,
+		})
 		.refine(
 			(val) => {
 				const lines = val
@@ -111,6 +117,9 @@ export const ScreenshotSchema = z.object({
 		.optional(),
 	cookies: z
 		.string()
+		.max(MAX_COOKIES_SIZE, {
+			message: `Cookies exceed maximum allowed size of ${MAX_COOKIES_SIZE} characters`,
+		})
 		.refine(
 			(val) => {
 				const lines = val

--- a/packages/schemas/src/screenshots.ts
+++ b/packages/schemas/src/screenshots.ts
@@ -225,6 +225,13 @@ export const ScreenshotSchema = z.object({
 							case "httponly":
 								cookieObj.httpOnly = true;
 								break;
+							case "max-age": {
+								const maxAge = Number.parseInt(attrVal, 10);
+								if (!Number.isNaN(maxAge)) {
+									cookieObj.expires = Math.floor(Date.now() / 1000) + maxAge;
+								}
+								break;
+							}
 						}
 					}
 					return cookieObj;

--- a/packages/schemas/src/screenshots.ts
+++ b/packages/schemas/src/screenshots.ts
@@ -112,7 +112,13 @@ export const ScreenshotSchema = z.object({
 			value
 				.split("\n")
 				.map((line) => line.trim())
-				.filter((l): l is string => l.length > 0),
+				.filter((l): l is string => l.length > 0)
+				.map((line) => {
+					const colonIdx = line.indexOf(":");
+					const name = line.slice(0, colonIdx).trim().toLowerCase();
+					const value = line.slice(colonIdx + 1).trim();
+					return { name, value } as { name: string; value: string };
+				}),
 		)
 		.optional(),
 	cookies: z
@@ -165,7 +171,16 @@ export const ScreenshotSchema = z.object({
 			value
 				.split("\n")
 				.map((line) => line.trim())
-				.filter((l): l is string => l.length > 0),
+				.filter((l): l is string => l.length > 0)
+				.map((line) => {
+					const firstSeg = line.split(";")[0] ?? "";
+					const eqIdx = firstSeg.indexOf("=");
+					if (eqIdx === -1) return null;
+					const name = firstSeg.slice(0, eqIdx).trim();
+					const value = firstSeg.slice(eqIdx + 1).trim();
+					return { name, value } as { name: string; value: string };
+				})
+				.filter((obj): obj is { name: string; value: string } => obj !== null),
 		)
 		.optional(),
 	bypass_csp: z

--- a/packages/schemas/src/screenshots.ts
+++ b/packages/schemas/src/screenshots.ts
@@ -94,7 +94,8 @@ export const ScreenshotSchema = z.object({
 					.map((l) => l.trim())
 					.filter((l): l is string => l.length > 0);
 				if (lines.length === 0) return true; // allow empty string handled by optional()
-				const headerRegex = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+:\s?.+$/;
+				// Header value: visible ASCII (0x20-0x7E) only – excludes control chars (0x00–0x1F, 0x7F)
+				const headerRegex = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+:\s*[ -~]+$/;
 				return lines.every((line) => headerRegex.test(line));
 			},
 			{


### PR DESCRIPTION
add user agent, headers, cookies, and CSP bypass options to screenshot schema and processing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizing screenshots with user agent, HTTP headers, cookies, and an option to bypass Content Security Policy (CSP).
  - Introduced a new "Authorization" section in the playground form, allowing users to input user agent, headers, cookies, and toggle CSP bypass when generating screenshots.

- **Enhancements**
  - Improved validation and handling of custom headers and cookies in the screenshot generation process.
  - Enhanced screenshot caching and lookup by normalizing headers and cookies and including user agent and CSP bypass flags.
  - Updated README with security and rate limit guidelines related to headers, cookies, and CSP bypass usage.

- **UI Improvements**
  - Added customizable icons for hint messages in form fields to improve user guidance and interface clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->